### PR TITLE
Fix CommandBuffer Resources Early Dropping

### DIFF
--- a/src/scene_uploader.rs
+++ b/src/scene_uploader.rs
@@ -409,7 +409,9 @@ pub fn setup(
     setup_command_buffer.add_cmd(EndCommandBuffer {});
 
     // submit
-    setup_command_buffer.submit(context.clone(), queue);
+    let recorded = setup_command_buffer.record(context.clone());
+    recorded.submit(queue);
+
     context.wait_idle();
 
     Scene {


### PR DESCRIPTION
However, this api is not fully safe yet as the user is required to ensure that the CPU command buffer out-lives the execution of the command buffer on the GPU.